### PR TITLE
Вложенные транзакции и savepoint'ы

### DIFF
--- a/core/OSQL/CreateTableQuery.class.php
+++ b/core/OSQL/CreateTableQuery.class.php
@@ -79,7 +79,12 @@
 				}
 			}
 			
-			return $out."\n);\n";
+			$out .= "\n)";
+			if ($dialect instanceof MyDialect) {
+				$out .= ' TYPE=innodb ';
+			}
+			
+			return $out.";\n";
 		}
 	}
 ?>

--- a/test/AllTests.php
+++ b/test/AllTests.php
@@ -127,6 +127,7 @@
 			}
 			
 			$suite->addTestSuite('DAOTest');
+			$suite->addTestSuite('TransactionTest');
 			
 			return $suite;
 		}

--- a/test/misc/TransactionTest.class.php
+++ b/test/misc/TransactionTest.class.php
@@ -1,0 +1,140 @@
+<?php
+	/* $Id$ */
+	
+	class TransactionTest extends TestTables
+	{	
+		public function create()
+		{
+			/**
+			 * @see testRecursionObjects() and meta
+			 * for TestParentObject and TestChildObject
+			**/
+			$this->schema->
+				getTableByName('test_parent_object')->
+				getColumnByName('root_id')->
+				dropReference();
+			
+			return parent::create();
+		}
+		
+		public function testData()
+		{
+			$this->create();
+			
+			foreach (DBTestPool::me()->getPool() as $connector => $db) {
+				DBPool::me()->setDefault($db);
+				$this->simpleTransaction();
+				
+				$this->innerTransactions();
+			}
+			
+			$this->drop();
+		}
+		
+		private function simpleTransaction()
+		{
+			$idList = $this->insertAndCommit();
+			$idList += $this->insertAndRollback();
+		}
+		
+		private function innerTransactions()
+		{
+			$dao = TestItem::dao();
+			
+			$idList = $this->externalCommit();
+			$idList = $this->externalRollback();
+			
+			$itemList = $dao->getListByIds($idList);
+			$this->assertEquals(count($idList), count($itemList));
+		}
+		
+		/**
+		 * @return array
+		**/
+		private function externalCommit()
+		{
+			$dao = TestItem::dao();
+			$db = DBPool::getByDao($dao);
+			$db->begin();
+			
+			$idList = $this->insertAndCommit();
+			$idList += $this->insertAndRollback();
+			
+			$db->commit();
+			
+			$itemList = $dao->getListByIds($idList);
+			$this->assertEquals(count($idList), count($itemList));
+			
+			return $idList;
+		}
+		
+		/**
+		 * @return array
+		**/
+		private function externalRollback()
+		{
+			$dao = TestItem::dao();
+			$db = DBPool::getByDao($dao);
+			$db->begin();
+			
+			$idList = $this->insertAndCommit();
+			$idList += $this->insertAndRollback();
+			
+			$db->rollback();
+			$dao->uncacheByIds($idList);
+			
+			$itemList = $dao->getListByIds($idList);
+			$this->assertTrue(empty($itemList));
+			
+			return array();
+		}
+		
+		/**
+		 * @return array
+		**/
+		private function insertAndCommit()
+		{
+			$dao = TestItem::dao();
+			$db = DBPool::getByDao($dao);
+			$db->begin();
+			
+			$item = $dao->add(TestItem::create()->setName('someItem'));
+			$itemId = $item->getId();
+			
+			$db->commit();
+			
+			try {
+				$dao->getById($itemId);
+			} catch (ObjectNotFoundException $e) {
+				$this->fail('Object must be saved');
+			}
+			
+			return array($itemId);
+		}
+		
+		/**
+		 * @return array
+		**/
+		private function insertAndRollback()
+		{
+			$dao = TestItem::dao();
+			$db = DBPool::getByDao($dao);
+			$db->begin();
+			
+			$item = $dao->add(TestItem::create()->setName('someItem'));
+			$itemId = $item->getId();
+			
+			$db->rollback();
+			$dao->uncacheById($itemId);
+			
+			try {
+				$dao->getById($itemId);
+				$this->fail('Object must not be saved');
+			} catch (ObjectNotFoundException $e) {
+				/* all ok */
+			}
+			
+			return array();
+		}
+	}
+?>


### PR DESCRIPTION
Issue, что бы видеть полный diff изменений и ссылаться на него.

Задачи:
- Исследовать возможность в различных базах использовать savepoint'ы
- Реализовать на savepoint'ах, там где они работают, возможность делать вложенные транзакции

Докиментация по savepoint'ам:

http://www.postgresql.org/docs/8.4/static/sql-savepoint.html
http://dev.mysql.com/doc/refman/5.0/en/savepoint.html 
http://www.sqlite.org/lang_savepoint.html (судя по всему только в sqlite3)

Исследовано:
- При генерации mysql базы данных нужно каким-то образом генерить innodb базу, а не myisam как это происходит сейчас - иначе транзакции в mysql вообще ни в каком виде не поддерживаются.
- Текущая версия sqlite используемая в onPHP не понимает savepoint'ы. Видимо нужно сделать для этого отдельный адаптер
- В postgres все работает как надо

Что надо сделать:
- Возможно вынести как-то работу с транзакциями в отдельный класс, что бы упростить код класса DB
- DB надо добавить свойства - поддерживает она транзакции или нет
- DB надо добавить свойства - поддерживает она savepoint'ы или нет
- Необходимо добавить настройка для DB - поддерживать или механизм вложенных транзакций на savepoint'ах

Что сейчас сделано:
- Модифицирован класс DB для работы в savepoint'ами и вложенными транзакциями
- Изменен класс CreateTableQuery **hack**'ом что бы при генерации mysql баз создавал их на движке innodb вместо дефолтного
- Написаны тесты для тестирвания обычных и вложенных транзакций.
